### PR TITLE
Setup page for admins to store an API key in local storage

### DIFF
--- a/Egineering.UrlShortener/Program.cs
+++ b/Egineering.UrlShortener/Program.cs
@@ -24,6 +24,12 @@ app.MapGet("/", async (HttpContext httpContext) =>
     await httpContext.Response.SendFileAsync("wwwroot/index.html");
 });
 
+app.MapGet("/setup", async (HttpContext httpContext) =>
+{
+    httpContext.Response.Headers.ContentType = "text/html; charset=UTF-8";
+    await httpContext.Response.SendFileAsync("wwwroot/setup.html");
+});
+
 app.MapGet("/{vanity}", async (string vanity, HttpContext httpContext, IAzureTableStorageService service) =>
 {
     try

--- a/Egineering.UrlShortener/wwwroot/css/setup.css
+++ b/Egineering.UrlShortener/wwwroot/css/setup.css
@@ -1,0 +1,42 @@
+﻿body {
+    font-family: 'Roboto', sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f5f5f5;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+h1 {
+    color: rgb(33,150,243);
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.setup-form {
+    background-color: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.mdl-textfield {
+    width: 100%;
+    margin-bottom: 20px;
+}
+
+.mdl-button {
+    display: block;
+    margin: 0 auto;
+}
+
+#setup-message {
+    margin-top: 20px;
+    text-align: center;
+    font-weight: bold;
+}

--- a/Egineering.UrlShortener/wwwroot/js/setup.js
+++ b/Egineering.UrlShortener/wwwroot/js/setup.js
@@ -1,0 +1,26 @@
+﻿
+const setupMessage = document.getElementById('setup-message');
+const setupForm = document.getElementById('setup-form');
+const keyInput = document.getElementById('key-input');
+
+function checkSetup() {
+    const storedKey = localStorage.getItem('eg_key');
+    if (storedKey) {
+        setupMessage.textContent = "Everything is good! The key is already set up.";
+        setupForm.style.display = 'none';
+    } else {
+        setupMessage.textContent = "";
+        setupForm.style.display = 'block';
+    }
+}
+
+setupForm.addEventListener('submit', function (e) {
+    e.preventDefault();
+    const key = keyInput.value.trim();
+    if (key) {
+        localStorage.setItem('eg_key', key);
+        checkSetup();
+    }
+});
+
+checkSetup();

--- a/Egineering.UrlShortener/wwwroot/setup.html
+++ b/Egineering.UrlShortener/wwwroot/setup.html
@@ -1,0 +1,35 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Setup - E-g Url Shortener</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue-orange.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link href="/css/index.css" rel="stylesheet" />
+    <link href="/css/setup.css" rel="stylesheet" />
+</head>
+<body>
+    <div class="container">
+        <h1>E-g Url Shortener Setup</h1>
+        <div id="setup-message"></div>
+        <form id="setup-form" class="setup-form">
+            <p>To access advanced functionality, please look up the key in 1Password and input it below:</p>
+            <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                <input class="mdl-textfield__input" type="text" id="key-input">
+                <label class="mdl-textfield__label" for="key-input">Enter key</label>
+            </div>
+            <button type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect">
+                Submit
+            </button>
+        </form>
+    </div>
+
+    <script src="/js/setup.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new setup page for the URL shortener application.

When the user visits, if they already have the key in local storage, display a message that all is good.

If the key is not in local storage, prompt them to look it up in 1Password and enter it. Then save it to local storage.

This key will be used in the future to authenticate API requests, restricting it to EG employees with access to the 1Password account.